### PR TITLE
Fix missing block device dependency for nova, cinder image

### DIFF
--- a/ContainerFiles/cinder
+++ b/ContainerFiles/cinder
@@ -63,7 +63,7 @@ LABEL org.opencontainers.image.description="OpenStack Service (cinder) built for
 COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y libxml2 multipath-tools open-iscsi qemu-block-extra qemu-utils systemctl \
+  && apt-get install --no-install-recommends -y libxml2 multipath-tools open-iscsi qemu-block-extra qemu-utils systemctl lsscsi nvme-cli \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \

--- a/ContainerFiles/nova
+++ b/ContainerFiles/nova
@@ -86,6 +86,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                                                 netcat-openbsd \
                                                 nfs-common \
                                                 nvme-cli \
+                                                lsscsi \
                                                 open-iscsi \
                                                 ovmf \
                                                 sysfsutils \


### PR DESCRIPTION
Adds a missing binary to fix warnings for nova-compute and cinder as lsscsi is missing and leading to warnings on resize.

This is related to the upstream issue
https://bugs.launchpad.net/bugs/1939390