### PR TITLE
feat: new multi stage container for libvirt

### DIFF
--- a/ContainerFiles/libvirt
+++ b/ContainerFiles/libvirt
@@ -2,35 +2,59 @@
 # This Dockerfile uses multi-stage build to customize DEV and PROD images:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
+# Stage 1: libguestfs_base
 ARG BUILT_TAG=v3.5.1-latest
+ARG BUILT_TAG_2=v1.56.1-latest
 FROM ghcr.io/rackerlabs/genestack-images/ovs:${BUILT_TAG} AS dependency_build
+
+# Final Stage: dependency_build
+FROM ghcr.io/rackerlabs/genestack-images/libguestfs:${BUILT_TAG_2}
 ARG CACHEBUST=0
 LABEL maintainer="Rackspace"
 LABEL vendor="Rackspace OpenStack Team"
 LABEL org.opencontainers.image.name="libvirt"
+COPY --from=dependency_build /usr/local /usr/local
+COPY --from=dependency_build /etc/openvswitch /etc/openvswitch
+COPY --from=dependency_build /var/lib/openvswitch /var/lib/openvswitch
+COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libbpf* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libcap-ng* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libcrypto* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libelf* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libnuma* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libssl* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libxdp* /lib/x86_64-linux-gnu/
+COPY --from=dependency_build /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y \
-                                             cgroup-tools \
-                                             dmidecode \
-                                             ebtables \
-                                             iproute2 \
-                                             ipxe-qemu \
-                                             kmod \
-                                             libvirt-clients \
-                                             libvirt-daemon-system \
-                                             openssh-client \
-                                             ovmf \
-                                             pm-utils \
-                                             qemu-block-extra \
-                                             qemu-efi \
-                                             qemu-efi-arm \
-                                             qemu-system \
-                                             qemu-utils \
+  && apt-get install --no-install-recommends -y iproute2 \
+                                                iptables \
+                                                cgroup-tools \
+                                                dmidecode \
+                                                ebtables \
+                                                iproute2 \
+                                                ipxe-qemu \
+                                                kmod \
+                                                libvirt-clients \
+                                                libvirt-daemon-system \
+                                                openssh-client \
+                                                ovmf \
+                                                pm-utils \
+                                                qemu-block-extra \
+                                                qemu-efi \
+                                                qemu-efi-arm \
+                                                qemu-system \
+                                                qemu-utils \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /etc/ssh/ssh_host_*_key \
+  && find / -name '*.pyc' -delete \
+  && find / -name '*.pyo' -delete \
+  && find / -name '__pycache__' -delete \
   && groupadd --system --gid 42424 nova \
   && useradd --system --gid 42424 --uid 42424 --shell /sbin/nologin --create-home --home /var/lib/nova nova \
   && mkdir -p /etc/nova /var/log/nova /var/cache/nova \
   && chown nova:nova /etc/nova /var/log/nova /var/lib/nova /var/cache/nova \
   && usermod -a -G kvm nova
+


### PR DESCRIPTION
libvirt, for admin_password injection at domain creation time, requires the libguestfs-tools pacakge.  Since we already have that package available in our libguestfs container, modify libvirt to be a three-stage container environment.  