### PR TITLE
Update nova container image

### DIFF
--- a/ContainerFiles/nova
+++ b/ContainerFiles/nova
@@ -100,7 +100,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && find / -name '*.pyo' -delete \
   && find / -name '__pycache__' -delete \
   && groupadd --system --gid 42424 nova \
-  && useradd --system --gid 42424 --uid 42424 --shell /sbin/nologin --create-home --home /var/lib/nova nova \
+  && useradd --system --gid 42424 --uid 42424 --shell /bin/bash --create-home --home /var/lib/nova nova \
   && mkdir -p /var/lib/openstack/etc/nova \
   && ln -s /var/lib/openstack/etc/nova /etc/nova \
   && chown nova:nova -h /etc/nova \


### PR DESCRIPTION
Libvirt remotefs operations use ssh to perform operations during migration, resize on remote hosts. As this same image is used for the nova-ssh container, the nova user must be able to login from other hosts via port 8022 and the shell login must be enabled to allow command execution