### PR TITLE
Adding NFS client for nfs backends

### DIFF
--- a/ContainerFiles/cinder
+++ b/ContainerFiles/cinder
@@ -63,7 +63,7 @@ LABEL org.opencontainers.image.description="OpenStack Service (cinder) built for
 COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y libxml2 multipath-tools open-iscsi qemu-block-extra qemu-utils systemctl lsscsi nvme-cli \
+  && apt-get install --no-install-recommends -y libxml2 multipath-tools open-iscsi qemu-block-extra qemu-utils systemctl lsscsi nvme-cli nfs-common \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \

--- a/ContainerFiles/glance
+++ b/ContainerFiles/glance
@@ -63,7 +63,7 @@ LABEL org.opencontainers.image.description="OpenStack Service (glance) built for
 COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y libxml2 \
+  && apt-get install --no-install-recommends -y libxml2 nfs-common \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
OpenStack storage services can use nfs as backend, especially cinder and nova requiring the NFS client installed