### PR TITLE
fix: python-memcached and apache2 fixes

### DIFF
--- a/ContainerFiles/gnocchi
+++ b/ContainerFiles/gnocchi
@@ -40,6 +40,7 @@ RUN curl -fsSL -o /tmp/upper-constraints.txt https://opendev.org/openstack/requi
                                         gnocchiclient \
                                         PyMySQL \
                                         pymemcache \
+                                        python-memcached \
                                         uwsgi
 
 COPY scripts/gnocchi-cve-patching.sh /opt/
@@ -58,7 +59,7 @@ RUN find / -name '*.pyc' -delete \
      done
 
 
-FROM python:3.12-slim-bookworm
+FROM ghcr.io/rackerlabs/genestack-images/apache:latest
 LABEL maintainer="Rackspace"
 LABEL vendor="Rackspace OpenStack Team"
 LABEL org.opencontainers.image.name="gnocchi"
@@ -89,4 +90,4 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 ENV PATH="/usr/local/bin:/usr/local/sbin:/var/lib/openstack/bin:$PATH"
 WORKDIR /var/lib/openstack
 USER 42424:42424
-ENTRYPOINT ["/var/lib/openstack/bin/gnocchi-upgrade"]
+ENTRYPOINT ["/usr/sbin/apache2ctl"]

--- a/docs/containers/gnocchi.md
+++ b/docs/containers/gnocchi.md
@@ -2,7 +2,7 @@
 
 The `gnocchi` image is built from [ContainerFiles/gnocchi](https://github.com/rackerlabs/genestack-images/blob/main/ContainerFiles/gnocchi). Security patches are applied by [scripts/gnocchi-cve-patching.sh](https://github.com/rackerlabs/genestack-images/blob/main/scripts/gnocchi-cve-patching.sh).
 
-This container packages the Gnocchi metric storage service for use in the stack. The build installs the required packages, applies security updates and configuration, and prepares the service for integration.
+This container packages the Gnocchi metric storage service for use in the stack. The build installs the required packages, applies security updates and configuration, and prepares the service for Apache/mod_wsgi integration.
 
 ``` mermaid
 graph LR
@@ -44,6 +44,7 @@ graph LR
 ## Dependencies
 
 - Builds From [Ceph Libs](ceph-libs.md)
+- Runtime Base [Apache](apache.md)
 
 ## Container Image
 


### PR DESCRIPTION
align the gnocchi container with the upstream openstack-helm gnocchi chart.  ensure we allow for correct apache2 conf overrides.  update the entry point and ensure python-memcached is installed.