### PR TITLE
fix(ceilometer):  Libvirt connectivity for Epoxy

### DIFF
--- a/ContainerFiles/ceilometer
+++ b/ContainerFiles/ceilometer
@@ -25,9 +25,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                                              libsasl2-dev \
                                              libssl-dev \
                                              libsystemd-dev \
+                                             libvirt-dev \
+                                             libvirt0 \
                                              libxml2-dev \
                                              libxslt1-dev \
                                              pkg-config \
+                                             python3-dev \
                                              ssl-cert \
                                              xmlsec1
 RUN curl -fsSL -o /tmp/upper-constraints.txt https://opendev.org/openstack/requirements/raw/branch/${OS_CONSTRAINTS}/upper-constraints.txt \
@@ -37,7 +40,8 @@ RUN curl -fsSL -o /tmp/upper-constraints.txt https://opendev.org/openstack/requi
                                         ceilometermiddleware \
                                         gnocchiclient \
                                         PyMySQL \
-                                        python-memcached
+                                        python-memcached \
+                                        libvirt-python
 
 COPY scripts/ceilometer-cve-patching.sh /opt/
 RUN bash /opt/ceilometer-cve-patching.sh
@@ -63,7 +67,7 @@ LABEL org.opencontainers.image.description="OpenStack Service (ceilometer) built
 COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y libxml2 \
+  && apt-get install --no-install-recommends -y libxml2 libvirt0 \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \

--- a/ContainerFiles/ceilometer
+++ b/ContainerFiles/ceilometer
@@ -10,29 +10,20 @@ ARG OS_CONSTRAINTS=master
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
   && apt-get install --no-install-recommends -y \
-                                             bash \
-                                             brotli \
                                              build-essential \
                                              curl \
-                                             docutils-common \
-                                             gettext \
                                              git \
                                              libffi-dev \
-                                             libjs-sphinxdoc \
-                                             libjs-underscore \
                                              libldap2-dev \
                                              libpq-dev \
                                              libsasl2-dev \
                                              libssl-dev \
                                              libsystemd-dev \
                                              libvirt-dev \
-                                             libvirt0 \
                                              libxml2-dev \
                                              libxslt1-dev \
                                              pkg-config \
-                                             python3-dev \
-                                             ssl-cert \
-                                             xmlsec1
+                                             python3-dev
 RUN curl -fsSL -o /tmp/upper-constraints.txt https://opendev.org/openstack/requirements/raw/branch/${OS_CONSTRAINTS}/upper-constraints.txt \
   && sed -i '/^ceilometer===.*/d' /tmp/upper-constraints.txt \
   && /var/lib/openstack/bin/pip install --constraint /tmp/upper-constraints.txt \


### PR DESCRIPTION
The ceilometer-compute pods were failing to discover VMs with an org.libvirt.unix.monitor is not registered polkit error. This happened because the default libvirt connection path goes through DBus/polkit, which doesn't work in containers where polkitd runs on the host - at least not anymore without further intervention.

This PR:
Adds libvirt0 runtime library to the container image (required for libvirt-python)
Cleans up unnecessary build-stage packages
Note: This also requires a helm override to set libvirt_uri = qemu+unix:///system?socket=/var/run/libvirt/libvirt-sock in ceilometer.conf (separate PR to genestack).