### PR TITLE
fix(ironic-conductor): isolinux/syslinux packages to ironic-conductor image

### DIFF
--- a/ContainerFiles/ironic-conductor
+++ b/ContainerFiles/ironic-conductor
@@ -61,7 +61,7 @@ LABEL org.opencontainers.image.description="OpenStack Service (ironic-conductor)
 COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y libxml2 ipmitool iproute2 qemu-utils genisoimage \
+  && apt-get install --no-install-recommends -y libxml2 ipmitool iproute2 qemu-utils genisoimage isolinux syslinux-common dosfstools mtools \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Install the required bootloader packages so /usr/lib/syslinux/isolinux.bin and ldlinux.c32 are present during Ironic provisioning. This is required to provision the BareMetal nodes using virtual media.

```bash
2026-04-18 04:23:01.904 1 ERROR ironic.common.images FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/syslinux/isolinux.bin' 
```