### PR TITLE
fix: use rackerlabs/keystone patched for cve's

### DIFF
--- a/ContainerFiles/keystone
+++ b/ContainerFiles/keystone
@@ -36,7 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
                                              ssl-cert \
                                              xmlsec1
 RUN /var/lib/openstack/bin/pip install --constraint https://opendev.org/openstack/requirements/raw/branch/${OS_CONSTRAINTS}/upper-constraints.txt \
-                                       git+https://opendev.org/openstack/keystone.git@${OS_VERSION}#egg=keystone \
+                                       git+https://github.com/rackerlabs/keystone.git@${OS_VERSION}#egg=keystone \
                                        git+https://github.com/rackerlabs/keystone-rxt@${RXT_VERSION}#egg=keystone_rxt \
                                        ldappool \
                                        pyngus \


### PR DESCRIPTION
Move to use a forked keystone (that is cve patched for  (CVE-2026-42998, CVE-2026-42999, CVE-2026-43000, CVE-2026-43001, CVE-2026-44394) while upstream works through adding the patches to the stable branches