### PR TITLE
fix(actions): Normalize IMAGE_NAME to lowercase

### DIFF
--- a/.github/workflows/container-build-alert-proxy.yaml
+++ b/.github/workflows/container-build-alert-proxy.yaml
@@ -49,6 +49,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-apache.yaml
+++ b/.github/workflows/container-build-apache.yaml
@@ -64,6 +64,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set environment variables
         run: |
           VERSION=$(echo -n "${{ matrix.apache-mod-wsgi-version }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-barbican.yaml
+++ b/.github/workflows/container-build-barbican.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-blazar.yaml
+++ b/.github/workflows/container-build-blazar.yaml
@@ -71,6 +71,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ceilometer.yaml
+++ b/.github/workflows/container-build-ceilometer.yaml
@@ -70,6 +70,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ceph-client.yaml
+++ b/.github/workflows/container-build-ceph-client.yaml
@@ -92,6 +92,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-cinder.yaml
+++ b/.github/workflows/container-build-cinder.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-cloudkitty.yaml
+++ b/.github/workflows/container-build-cloudkitty.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-designate.yaml
+++ b/.github/workflows/container-build-designate.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-freezer.yaml
+++ b/.github/workflows/container-build-freezer.yaml
@@ -68,6 +68,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-glance-ceph.yaml
+++ b/.github/workflows/container-build-glance-ceph.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-glance.yaml
+++ b/.github/workflows/container-build-glance.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-gnocchi.yaml
+++ b/.github/workflows/container-build-gnocchi.yaml
@@ -73,6 +73,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.gnocchi-version }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-heat.yaml
+++ b/.github/workflows/container-build-heat.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-horizon.yaml
+++ b/.github/workflows/container-build-horizon.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ironic-api.yaml
+++ b/.github/workflows/container-build-ironic-api.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ironic-conductor.yaml
+++ b/.github/workflows/container-build-ironic-conductor.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ironic-inspector.yaml
+++ b/.github/workflows/container-build-ironic-inspector.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-ironic-pxe.yaml
+++ b/.github/workflows/container-build-ironic-pxe.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-keystone.yaml
+++ b/.github/workflows/container-build-keystone.yaml
@@ -84,6 +84,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-kube-ovn.yaml
+++ b/.github/workflows/container-build-kube-ovn.yaml
@@ -66,6 +66,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set environment variables
         run: |
           VERSION=$(echo -n "${{ matrix.kube-ovn-version }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-kubectl.yaml
+++ b/.github/workflows/container-build-kubectl.yaml
@@ -49,6 +49,8 @@ jobs:
           images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest'
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-kubernetes-entrypoint.yaml
+++ b/.github/workflows/container-build-kubernetes-entrypoint.yaml
@@ -50,6 +50,8 @@ jobs:
           images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest'
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-libguestfs.yaml
+++ b/.github/workflows/container-build-libguestfs.yaml
@@ -78,6 +78,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set environment variables
         run: |
           VERSION=$(echo -n "${{ matrix.libguestfs-version }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-libvirt.yaml
+++ b/.github/workflows/container-build-libvirt.yaml
@@ -49,6 +49,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-magnum.yaml
+++ b/.github/workflows/container-build-magnum.yaml
@@ -86,6 +86,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-manila.yaml
+++ b/.github/workflows/container-build-manila.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-masakari-monitors.yaml
+++ b/.github/workflows/container-build-masakari-monitors.yaml
@@ -77,6 +77,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-masakari.yaml
+++ b/.github/workflows/container-build-masakari.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-neutron.yaml
+++ b/.github/workflows/container-build-neutron.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-nova.yaml
+++ b/.github/workflows/container-build-nova.yaml
@@ -86,6 +86,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-octavia.yaml
+++ b/.github/workflows/container-build-octavia.yaml
@@ -87,6 +87,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-openstack-client.yaml
+++ b/.github/workflows/container-build-openstack-client.yaml
@@ -49,6 +49,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-openstack-venv.yaml
+++ b/.github/workflows/container-build-openstack-venv.yaml
@@ -50,6 +50,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-ovs.yaml
+++ b/.github/workflows/container-build-ovs.yaml
@@ -64,6 +64,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set environment variables
         run: |
           VERSION=$(echo -n "${{ matrix.ovs-version }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-placement.yaml
+++ b/.github/workflows/container-build-placement.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-shibd.yaml
+++ b/.github/workflows/container-build-shibd.yaml
@@ -49,6 +49,8 @@ jobs:
           images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest'
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/container-build-skyline.yaml
+++ b/.github/workflows/container-build-skyline.yaml
@@ -70,6 +70,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-tempest.yaml
+++ b/.github/workflows/container-build-tempest.yaml
@@ -69,6 +69,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-trove.yaml
+++ b/.github/workflows/container-build-trove.yaml
@@ -72,6 +72,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')

--- a/.github/workflows/container-build-zaqar.yaml
+++ b/.github/workflows/container-build-zaqar.yaml
@@ -71,6 +71,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Dynamically set MY_DATE environment variable
         run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Dynamically set OS_VERSION_PARSE environment variable
         run: |
           VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')


### PR DESCRIPTION
Container registries (including ghcr.io) require image repository names to be lowercase. When github.repository contains uppercase characters (e.g., from an organization or repo name with mixed case), docker push and trivy image scans fail with "invalid reference format" errors.

Add a "Normalize image repository name" step to every container-build workflow that lowercases IMAGE_NAME before it is consumed by the metadata, build-push, and trivy actions. Mirrors the existing pattern already in container-build-gnocchi.yaml.