### PR TITLE
fix(gnocchi): pin numpy to >=2.3.2,<3 to avoid metricd memory leak

### DIFF
--- a/ContainerFiles/gnocchi
+++ b/ContainerFiles/gnocchi
@@ -9,10 +9,11 @@ ARG GNOCCHI_VERSION=master
 ARG OS_CONSTRAINTS=master
 RUN export DEBIAN_FRONTEND=noninteractive
 RUN curl -fsSL -o /tmp/upper-constraints.txt https://opendev.org/openstack/requirements/raw/branch/${OS_CONSTRAINTS}/upper-constraints.txt \
-  && sed -i '/^gnocchi===.*/d' /tmp/upper-constraints.txt \
+  && sed -i -e '/^gnocchi===.*/d' -e '/^numpy===.*/d' /tmp/upper-constraints.txt \
   && /var/lib/openstack/bin/pip install -vvv --no-cache-dir --constraint /tmp/upper-constraints.txt \
                                         "gnocchi[postgresql,ceph,keystone,redis] @ git+https://github.com/gnocchixyz/gnocchi.git@${GNOCCHI_VERSION}" \
                                         gnocchiclient \
+                                        "numpy>=2.3.2,<3" \
                                         PyMySQL \
                                         pymemcache \
                                         SQLAlchemy \


### PR DESCRIPTION
OpenStack 2025.1 upper-constraints pins numpy===2.2.3, which contains the regression introduced in numpy 2.2.0 that leaks memory on np.datetime64 hashing. Gnocchi metricd hits this hard through its storage layer and shows steady, unbounded RSS growth.

Strip the upstream numpy=== line from upper-constraints.txt (alongside the existing gnocchi=== strip) and pin numpy>=2.3.2,<3 on the pip install line so all build branches converge on a known-good range:

  - master      (numpy 2.4.6) : stays on 2.4.6
  - stable/4.7  (numpy 2.2.3) : upgraded into 2.3.x
  - stable/4.6  (numpy 1.26.4): upgraded into 2.3.x

Refs: https://github.com/gnocchixyz/gnocchi/issues/1463
Refs: https://github.com/numpy/numpy/issues/29397
Jira: https://rackspace.atlassian.net/browse/OSPC-2213