### PR TITLE
feat(shibd): install newest shibboleth-sp from sid

### DIFF
--- a/.github/workflows/container-build-shibd.yaml
+++ b/.github/workflows/container-build-shibd.yaml
@@ -65,6 +65,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHEBUST=${{ github.sha }}
+      - name: Extract shibboleth-sp version from built image
+        run: |
+          SHIBD_VERSION=$(docker run --rm --entrypoint dpkg-query \
+              "${IMAGE_NAME}:local" \
+              -W -f '${Version}' shibboleth-sp-utils \
+              | sed 's/[+~-].*//')
+          if [[ -z "${SHIBD_VERSION}" ]]; then
+            echo "::error::Could not determine shibboleth-sp version from image"
+            exit 1
+          fi
+          echo "Detected shibboleth-sp version: ${SHIBD_VERSION}"
+          echo "SHIBD_VERSION=${SHIBD_VERSION}" >> "$GITHUB_ENV"
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0  # using latest trivy scanner
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
@@ -116,7 +128,8 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.MY_DATE }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SHIBD_VERSION }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SHIBD_VERSION }}-${{ env.MY_DATE }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHEBUST=${{ github.sha }}

--- a/ContainerFiles/shibd
+++ b/ContainerFiles/shibd
@@ -8,18 +8,40 @@ LABEL maintainer="Rackspace"
 LABEL vendor="Rackspace OpenStack Team"
 LABEL org.opencontainers.image.name="shibd"
 
+# We want the newest shibboleth-sp point release available in Debian, which
+# often lands in sid before it reaches the current stable release. Debian sid
+# is layered as an additional apt source and apt pinning is scoped so that
+# ONLY the shibboleth-sp source package (and everything built from it) prefers
+# sid; everything else stays on the base image's suite because sid's catch-all
+# priority (100) is below the default (500). Any strict dependency that only
+# exists in sid is still reachable. If a newer point release later appears in
+# the base suite, apt will simply pick that one (same or higher version wins)
+# and the sid pin becomes a no-op. The sid sources/pin files are removed after
+# install so the resulting image ships a plain apt configuration.
 RUN export DEBIAN_FRONTEND=noninteractive \
+  && echo "deb http://deb.debian.org/debian sid main" \
+       > /etc/apt/sources.list.d/sid.list \
+  && printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n\nPackage: src:shibboleth-sp\nPin: release a=unstable\nPin-Priority: 990\n' \
+       > /etc/apt/preferences.d/shibboleth-sp \
   && apt-get update && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y shibboleth-sp-utils \
+  && apt-get install --no-install-recommends -y shibboleth-sp-utils iproute2 \
+  && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/shibboleth-sp \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean -y \
   && find / -name '*.pyc' -delete \
   && find / -name '*.pyo' -delete \
   && find / -name '__pycache__' -delete \
-  && sed -i 's@fileName=.*@fileName=/dev/stdout@g' /etc/shibboleth/*.logger
+  && sed -i 's@fileName=.*@fileName=/dev/stdout@g' /etc/shibboleth/*.logger \
+  && printf '\n========================================================================\n Installed Shibboleth SP packages\n========================================================================\n' \
+  && dpkg-query -W -f '${Package} ${Version} (${Architecture})\n' \
+       shibboleth-sp-common libshibsp12 libshibsp-plugins shibboleth-sp-utils \
+  && printf '========================================================================\n' \
+  && shibd -v || true \
+  && printf '========================================================================\n\n' \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set the user and group to match the original build
 USER 42424:42424
 
-# Set the entrypoint to the keystone-manage command
+# Set the entrypoint to the shibd command
 ENTRYPOINT ["/usr/sbin/shibd"]


### PR DESCRIPTION
Debian stable lags newer shibboleth-sp point releases. Layer sid as an additional apt source with pinning scoped to the shibboleth-sp source package so only its binaries prefer sid; everything else stays on the base suite. The pin degrades to a no-op once the base suite catches up.

Also install iproute2 so `ss` is available in the image for connectivity troubleshooting, emit a version banner at the end of the install step so build logs report the exact shib package versions installed, and publish the pushed image under three tags: `latest`, `<shib-version>` (e.g. `3.5.2`, weekly moving pointer), and `<shib-version>-<epoch>` (immutable snapshot for pod pinning).

Jira: https://rackspace.atlassian.net/browse/OSPC-2171