### PR TITLE
feat(ironic): add Prometheus exporter container image

### DIFF
--- a/.github/workflows/container-build-ironic-prometheus-exporter.yaml
+++ b/.github/workflows/container-build-ironic-prometheus-exporter.yaml
@@ -1,0 +1,166 @@
+---
+name: Create and publish an Ironic prometheus exporter image
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  packages: write
+  pull-requests: write
+  security-events: write
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/container-build-ironic-prometheus-exporter.yaml
+      - ContainerFiles/ironic-prometheus-exporter
+  schedule:
+    - cron: '0 0 * * 0'  # Run Weekly at midnight UTC
+  workflow_dispatch:
+    inputs:
+      openstack-constraints:
+        description: 'Version of OpenStack Constraints to use'
+        required: true
+        default: "master"
+        type: choice
+        options:
+          - master
+          - unmaintained/2024.1
+          - stable/2025.1
+          - stable/2026.1
+      project-version:
+        description: 'Version of OpenStack Ironic to build, defaults to openstack-constraints if unspecified'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/ironic-prometheus-exporter
+  project_version: ${{ github.event.inputs.project-version }}
+  # NOTE(cloudnull): This is used to parse the workflow_dispatch inputs, sadly the inputs are not available in the
+  #                   workflow_dispatch event, so they're being stored in the environment variables. This is a
+  #                   workaround until there's a better way to handle this.
+  openstack_constraints: >
+    ["stable/2025.1", "stable/2026.1"]
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      openstack-constraints: ${{ steps.generate-matrix.outputs.openstack_constraints }}
+    steps:
+      - name: generate-matrix
+        id: generate-matrix
+        run: |
+          if [ "${{ github.event_name == 'workflow_dispatch' }}" = "true" ]; then
+            openstack_constraints="$(echo '${{ github.event.inputs.openstack-constraints }}' | jq -R '[select(length>0)]' | jq -c '.')"
+          fi
+          echo "openstack_constraints=${openstack_constraints:-${{ env.openstack_constraints }}}" >> $GITHUB_OUTPUT
+  build-and-push-image:
+    needs:
+      - init
+    strategy:
+      matrix:
+        openstack-constraints: ${{ fromJSON(needs.init.outputs.openstack-constraints)}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Dynamically set MY_DATE environment variable
+        run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Normalize image repository name
+        run: echo "IMAGE_NAME=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Dynamically set OS_VERSION_PARSE environment variable
+        run: |
+          VERSION=$(echo -n "${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}" | awk -F'/' '{($2=="" ? x=$1 : x=$2); print x}')
+          echo "OS_VERSION_PARSE=${VERSION}" >> $GITHUB_ENV
+          NAME=$(echo -n "${{ env.IMAGE_NAME }}" | awk -F'/' '{print $NF}')
+          echo "CATEGORY_NAME=${VERSION}-${NAME}" >> $GITHUB_ENV
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ContainerFiles/ironic-prometheus-exporter
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.IMAGE_NAME }}:local
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OS_VERSION=${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}
+            OS_CONSTRAINTS=${{ matrix.openstack-constraints }}
+            CACHEBUST=${{ github.sha }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.35.0  # using latest trivy scanner
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+        with:
+          image-ref: '${{ env.IMAGE_NAME }}:local'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        continue-on-error: true
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: "${{ env.CATEGORY_NAME }}"
+      - name: Run Trivy scanner
+        uses: aquasecurity/trivy-action@0.35.0  # using latest trivy scanner
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          image-ref: '${{ env.IMAGE_NAME }}:local'
+          output: trivy.txt
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+      - name: Create trivy output file in markdown format
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ -s trivy.txt ]]; then
+              echo "### Security Output" > trivy-output.txt
+              echo '```terraform' >> trivy-output.txt
+              cat trivy.txt >> trivy-output.txt
+              echo '```' >> trivy-output.txt
+          fi
+      - name: Publish Trivy Output to Summary
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ -s trivy-output.txt ]]; then
+            {
+              cat trivy-output.txt
+            } >> $GITHUB_STEP_SUMMARY
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ContainerFiles/ironic-prometheus-exporter
+          push: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.OS_VERSION_PARSE }}-latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.OS_VERSION_PARSE }}-${{ env.MY_DATE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OS_VERSION=${{ env.project_version != '' && env.project_version || matrix.openstack-constraints }}
+            OS_CONSTRAINTS=${{ matrix.openstack-constraints }}
+            CACHEBUST=${{ github.sha }}

--- a/ContainerFiles/ironic-prometheus-exporter
+++ b/ContainerFiles/ironic-prometheus-exporter
@@ -1,0 +1,78 @@
+# syntax = docker/dockerfile:1
+# This Dockerfile uses multi-stage build to customize DEV and PROD images:
+# https://docs.docker.com/develop/develop-images/multistage-build/
+
+ARG VENV_TAG=3.12-latest
+FROM ghcr.io/rackerlabs/genestack-images/openstack-venv:${VENV_TAG} AS dependency_build
+ARG CACHEBUST=0
+ARG OS_VERSION=master
+ARG OS_CONSTRAINTS=master
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update && apt-get upgrade -y \
+  && apt-get install --no-install-recommends -y \
+                                             bash \
+                                             build-essential \
+                                             curl \
+                                             gettext \
+                                             git \
+                                             libssl-dev \
+                                             libsystemd-dev \
+                                             pkg-config \
+                                             ssl-cert \
+                                             xmlsec1
+
+
+RUN /var/lib/openstack/bin/pip install --constraint https://opendev.org/openstack/requirements/raw/branch/${OS_CONSTRAINTS}/upper-constraints.txt \
+                                       git+https://opendev.org/openstack/ironic-prometheus-exporter.git@${OS_VERSION}#egg=ironic-prometheus-exporter \
+                                       gunicorn
+
+COPY scripts/ironic-cve-patching.sh /opt/
+RUN bash /opt/ironic-cve-patching.sh
+
+RUN find / -name '*.pyc' -delete \
+    && find / -name '*.pyo' -delete \
+    && find / -name '__pycache__' -delete \
+    && find / -name '*.whl' -delete \
+    && rm -f /var/lib/openstack/lib/python*/site-packages/slapdtest/certs/client.key \
+    && rm -f /var/lib/openstack/lib/python*/site-packages/slapdtest/certs/server.key \
+    && sed -i '/^Usage/,/^Documentation\n^-.*$/d' /var/lib/openstack/lib/python*/site-packages/PyJWT-*.dist-info/METADATA || true
+
+FROM python:3.12-slim-bookworm
+
+LABEL maintainer="Rackspace"
+LABEL vendor="Rackspace OpenStack Team"
+LABEL org.opencontainers.image.name="ironic-prometheus-exporter"
+LABEL org.opencontainers.image.description="Ironic Prometheus Exporter"
+
+COPY --from=dependency_build /var/lib/openstack /var/lib/openstack
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && find / -name '*.pyc' -delete \
+    && find / -name '*.pyo' -delete \
+    && find / -name '__pycache__' -delete \
+    && groupadd --system --gid 42424 ironic \
+    && useradd --system --gid 42424 --uid 42424 --shell /sbin/nologin --create-home --home /var/lib/ironic ironic \
+    && mkdir -p /var/lib/openstack/etc/ironic \
+    && ln -s /var/lib/openstack/etc/ironic /etc/ironic \
+    && chown ironic:ironic -h /etc/ironic \
+    && chown -R ironic:ironic /var/lib/openstack/etc/ironic
+
+# Set the environment variables for the ironic-prometheus-exporter
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/var/lib/openstack/bin:$PATH"
+# Set the working directory
+WORKDIR /var/lib/openstack
+# Set the user and group to match the original build
+USER 42424:42424
+# Expose port from environment variable, default to 9608
+ARG EXPORTER_PORT=9608
+ENV EXPORTER_PORT=${EXPORTER_PORT}
+EXPOSE ${EXPORTER_PORT}
+
+# Run the exporter
+CMD ["sh", "-c", "exec gunicorn -b 0.0.0.0:${EXPORTER_PORT} -w 4 ironic_prometheus_exporter.app.wsgi:application"]

--- a/docs/containers/ironic-prometheus-exporter.md
+++ b/docs/containers/ironic-prometheus-exporter.md
@@ -1,0 +1,49 @@
+# Ironic Prometheus Exporter
+
+The `ironic-prometheus-exporter` image is built from [ContainerFiles/ironic-prometheus-exporter](https://github.com/rackerlabs/genestack-images/blob/main/ContainerFiles/ironic-prometheus-exporter). Security patches are applied by [scripts/ironic-cve-patching.sh](https://github.com/rackerlabs/genestack-images/blob/main/scripts/ironic-cve-patching.sh).
+
+This container packages the Ironic Prometheus Exporter service for use in the stack. The build installs the required packages, applies security updates and configuration, and prepares the service for integration.
+
+``` mermaid
+graph LR
+    A[Base image] --> B[Install packages]
+    B --> C[Apply CVE patches]
+    C --> D[Configure Ironic Prometheus Exporter]
+    D --> E[Container ready]
+```
+
+??? example "ContainerFile used for the build"
+
+    ``` docker
+    --8<-- "ContainerFiles/ironic-prometheus-exporter"
+    ```
+
+## Build Arguments
+
+| Argument | Default |
+| --- | --- |
+| VENV_TAG | 3.12-latest |
+| CACHEBUST | 0 |
+| OS_VERSION | master |
+| OS_CONSTRAINTS | master |
+
+??? example "Build Command"
+
+    ``` bash
+    docker build \
+    --build-arg VENV_TAG=3.12-latest \
+    --build-arg CACHEBUST=0 \
+    --build-arg OS_VERSION=master \
+    --build-arg OS_CONSTRAINTS=master \
+    -f ContainerFiles/ironic-prometheus-exporter \
+    -t ironic-prometheus-exporter:local \
+    .
+    ```
+
+## Dependencies
+
+- Builds From [OpenStack Virtual Environment](openstack-venv.md)
+
+## Container Image
+
+The container image is available on [Github Container Registry](https://github.com/rackerlabs/genestack-images/pkgs/container/genestack-images%2Fironic-prometheus-exporter).


### PR DESCRIPTION
Add a multi-stage container build for the Ironic Prometheus Exporter.

- install the exporter from the OpenStack source repository
- support configurable project and constraint versions
- run the service as a non-root user with Gunicorn and expose the exporter on port 9608
- add GitHub Actions builds for supported OpenStack releases
- scan images with Trivy and upload scheduled scan results
- publish versioned and latest images to GHCR
- document build arguments, dependencies, and image usage